### PR TITLE
Updated "$Tag" to 1.3.

### DIFF
--- a/WingetPathUpdaterInstall.ps1
+++ b/WingetPathUpdaterInstall.ps1
@@ -26,7 +26,7 @@ param( [switch] $Force,
         # URL, plus the version info in the ARP registry values (DisplayVersion and
         # VersionMajor/VersionMinor). (And then each winget manifest has the installer
         # version as well, plus the URL of this script.)
-        [string] $Tag = 'v1.2'
+        [string] $Tag = 'v1.3'
      )
 
 try
@@ -344,4 +344,5 @@ catch
 
     exit -1
 }
+
 


### PR DESCRIPTION
At the time of writing, installing the Winget 1.3 manifest has the resulting installation show up as a version 1.2 instead, causing `winget update` to always think a new update is available when there actually isn't one.

So I'm attempting this workaround to see if that fixes it.

Log of sorts:
```
PS (...)> winget update
Name                                         Id                                 Version   Available            Source
---------------------------------------------------------------------------------------------------------------------
WingetPathUpdater                            jazzdelightsme.WingetPathUpdater   1.2       1.3                  winget
(...)
PS (...)> winget show jazzdelightsme.WingetPathUpdater
Found WingetPathUpdater [jazzdelightsme.WingetPathUpdater]
Version: 1.3
Publisher: jazzdelightsme
Publisher Url: https://github.com/jazzdelightsme
Author: jazzdelightsme
Moniker: wingetpathupdater
Description: Addresses winget-cli #549 by providing shell wrapper scripts to update your PATH.
Homepage: https://github.com/jazzdelightsme/WingetPathUpdater
License: MIT License
Tags:
  environment
  path
  winget
Installer:
  Installer Type: exe
  Installer Url: https://github.com/jazzdelightsme/PowershellStub/releases/download/v2.0.0/PowershellStub.exe
  Installer SHA256: fc093668f648fba3f13234837f4dae93c46cea9ede4f4e045ef35a8fc3aa7a06
  Offline Distribution Supported: true
```